### PR TITLE
Service: Add unpair command for different situation

### DIFF
--- a/samples/central_esl/src/main.c
+++ b/samples/central_esl/src/main.c
@@ -292,7 +292,7 @@ static void button_handler(uint32_t button_state, uint32_t has_changed)
 
 	if (button & DK_BTN2_MSK) {
 #if defined(CONFIG_BT_ESL_TAG_STORAGE)
-		bt_c_esl_unbond(-1);
+		bt_c_esl_unbond_all();
 		remove_all_tags_in_storage();
 #endif
 	}

--- a/service/esl_client.h
+++ b/service/esl_client.h
@@ -473,16 +473,29 @@ int bt_esl_c_display_control(struct bt_esl_client *esl_c, uint8_t conn_idx, uint
 int bt_esl_c_led_control(struct bt_esl_client *esl_c, uint8_t conn_idx, uint8_t led_idx,
 			 struct led_obj *led, bool timed, uint32_t abs_time);
 
-/** @brief Clear bonding data
+/**
+ * Unbond the specified ESL by BLE address.
  *
- * Ask AP to clear bonding data for current ACL connection
- *
- * @param[in] conn_idx Index of ACL connection to remove bond. -1 means remove all of bonding data.
- *
- * @retval 0 If the operation was successful.
- *           Otherwise, a negative error code is returned.
+ * @param addr The address of the device to unbond.
+ * @return 0 on success, or a negative error code on failure.
  */
-int bt_c_esl_unbond(int conn_idx);
+int bt_c_esl_unbond(const bt_addr_le_t *addr);
+
+/**
+ * Unbond all ESL Tags.
+ *
+ * @return 0 if successful, otherwise an error code.
+ */
+int bt_c_esl_unbond_all(void);
+
+/**
+ * Unbonds an ESL device with the specified ESL address.
+ * Look up ESL tag BLE address in the tag DB and unbond it.
+ *
+ * @param esl_addr The ESL address of the device to unbond.
+ * @return 0 if the device was successfully unbonded, or a negative error code otherwise.
+ */
+int bt_c_esl_unbond_by_esl_addr(uint16_t esl_addr);
 
 /** @brief Start/stop to scan ESL service.
  *

--- a/service/esl_client_tag_storage.c
+++ b/service/esl_client_tag_storage.c
@@ -337,7 +337,6 @@ int load_all_tags_in_storage(uint8_t group_id)
 	return rc;
 }
 
-/* type 0 list esl, type 1 list ble*/
 int list_tags_in_storage(uint8_t type)
 {
 	int rc;
@@ -404,6 +403,13 @@ int remove_tag_in_storage(uint16_t esl_addr, const bt_addr_le_t *peer_addr)
 
 		bt_addr_to_str(&ble_addr.a, addr, BT_ADDR_STR_LEN);
 		LOG_INF("find addr %s", addr);
+	} else {
+		bt_addr_le_copy(&ble_addr, peer_addr);
+	}
+
+	rc = bt_c_esl_unbond(&ble_addr);
+	if (rc) {
+		LOG_ERR("FAIL: bt_c_esl_unbond %s: %d", addr, rc);
 	}
 
 	fs_file_t_init(&file);

--- a/service/esl_client_tag_storage.h
+++ b/service/esl_client_tag_storage.h
@@ -11,11 +11,63 @@
 
 #include "esl_common.h"
 
+/**
+ * @brief Saves the given ESL data in the storage.
+ *
+ * This function saves the given tag data in the storage with the BLE address and the ESL address.
+ * The tag data includes the BLE address, ESL address, ESL response key, and DIS PnP ID.
+ * The function creates a file for each tag with the BLE address and the ESL address as the file
+ * name.
+ *
+ * @param tag Pointer to the tag data to be saved.
+ * @return 0 on success, negative errno code on error.
+ */
 int save_tag_in_storage(const struct bt_esl_chrc_data *tag);
+
+/**
+ * @brief Loads the ESL data from the file system storage.
+ *
+ * This function loads the tag data from the file system storage by opening the file with the given
+ * BLE address, reading the data from the file and storing it in the given tag structure.
+ *
+ * @param ble_addr The BLE address of the tag to be loaded.
+ * @param tag The tag structure to store the loaded data.
+ *
+ * @return 0 on success, negative errno code on error.
+ */
 int load_tag_in_storage(const bt_addr_le_t *ble_addr, struct bt_esl_chrc_data *tag);
+/**
+ * Searches for a ESL Bluetooth address in the storage with the given ESL address
+ *
+ * @param [in] esl_addr The ESL address to search for.
+ * @param [out] ble_addr The Bluetooth address to search for.
+ * @return 0 if found, or negative value if not found.
+ */
 int find_tag_in_storage_with_esl_addr(uint16_t esl_addr, bt_addr_le_t *ble_addr);
-/* type 0 list esl, type 1 list ble*/
+
+/**
+ * @brief Lists all the tags in the storage directory based on the type.
+ *
+ * @param type The type of the list to be displayed. 0 for ESL list and 1 for BLE list.
+ *
+ * @return Returns 0 on success or an error code on failure.
+ */
 int list_tags_in_storage(uint8_t type);
+
+/**
+ * @brief Removes a tag from storage based on its ESL address and peer address.
+ *
+ * This function removes a tag from storage based on its ESL address and peer address. If the peer
+ * address is NULL, the function uses the ESL address to find the tag in BLE_ADDR storage. If the
+ * tag is found, it is unbonded and the corresponding BLE_ADDR and ESL_ADDR files are removed from
+ * storage.
+ *
+ * @param esl_addr The ESL address of the tag to be removed.
+ * @param peer_addr The peer address of the tag to be removed. If NULL, the function uses the ESL
+ * address to find the tag in BLE_ADDR storage.
+ *
+ * @return 0 on success, negative errno code on error.
+ */
 int remove_tag_in_storage(uint16_t esl_addr, const bt_addr_le_t *peer_addr);
 
 #endif /* ESL_CLIENT_TAG_STORAGE_H_ */


### PR DESCRIPTION
bt_c_esl_unbond accept BLE address.
bt_c_esl_unbond_all unbond all ESL tag.
bt_c_esl_unbond_by_esl_addr accept ESL address.
remove_tag_in_storage also unbond ESL.