### PR TITLE
Sample: Fix complie fail when auto AP disable

### DIFF
--- a/service/esl_client.c
+++ b/service/esl_client.c
@@ -190,8 +190,8 @@ bool esl_c_auto_ap_mode =
 uint16_t esl_c_tags_per_group =
 	COND_CODE_1(CONFIG_BT_ESL_AP_AUTO_MODE, (CONFIG_BT_ESL_AP_AUTO_TAG_PER_GROUP),
 		    (CONFIG_ESL_CLIENT_MAX_RESPONSE_SLOT_BUFFER));
-uint8_t groups_per_button =
-	COND_CODE_1(CONFIG_BT_ESL_AP_AUTO_MODE, (CONFIG_BT_ESL_AP_GROUP_PER_BUTTON), 1);
+uint8_t groups_per_button = COND_CODE_1(IS_ENABLED(CONFIG_BT_ESL_AP_AUTO_MODE),
+					(CONFIG_BT_ESL_AP_GROUP_PER_BUTTON), (1));
 bool esl_c_write_wo_rsp;
 
 /**
@@ -787,7 +787,7 @@ static void esl_c_auto_configuring_tag(uint8_t conn_idx)
 			LOG_ERR("No space in the queue for qk_data");
 		}
 
-		break;		
+		break;
 	default:
 		LOG_WRN("Not predefied tag, should manually configuring");
 		break;
@@ -1145,9 +1145,9 @@ static void connected(struct bt_conn *conn, uint8_t conn_err)
 #if defined(CONFIG_BT_ESL_TAG_STORAGE)
 	esl_tag_load_work.ble_addr = peer;
 	esl_tag_load_work.conn_idx = conn_idx;
+	k_work_reschedule(&esl_tag_load_work.work, K_NO_WAIT);
 #endif /* CONFIG_BT_ESL_TAG_STORAGE */
 
-	k_work_reschedule(&esl_tag_load_work.work, K_NO_WAIT);
 
 	tag = esl_c_get_tag_addr(-1, peer);
 	if (tag) {

--- a/service/esl_client_shell.c
+++ b/service/esl_client_shell.c
@@ -1198,6 +1198,7 @@ static void export_bt_key(const struct bt_bond_info *info, void *user_data)
 	}
 }
 
+#if defined(CONFIG_BT_ESL_TAG_BT_KEY_STORAGE)
 static int cmd_acl_bt_key_import(const struct shell *shell, size_t argc, char *argv[])
 {
 	if (argc < 3) {
@@ -1247,6 +1248,7 @@ static int cmd_acl_bt_key_import(const struct shell *shell, size_t argc, char *a
 
 	return err;
 }
+#endif
 
 static int cmd_acl_bt_key_export(const struct shell *shell, size_t argc, char *argv[])
 {
@@ -1408,8 +1410,10 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	SHELL_CMD(connect, NULL, "Connect advertising ESL service tag", cmd_acl_connect),
 	SHELL_CMD(connect_addr, NULL, "Connect advertising ESL service or synced tag with ble addr",
 		  cmd_acl_connect_addr),
+#if defined(CONFIG_BT_ESL_TAG_BT_KEY_STORAGE)
 	SHELL_CMD(bt_key_import, NULL, "ESL AP import BT bonding key runtime",
 		  cmd_acl_bt_key_import),
+#endif /* CONFIG_BT_ESL_TAG_BT_KEY_STORAGE */
 	SHELL_CMD(bt_key_export, NULL, "ESL AP export bond key", cmd_acl_bt_key_export),
 	SHELL_CMD(bd_addr, NULL, "ESL AP BD Addr", cmd_bd_addr),
 #if defined(CONFIG_BT_ESL_TAG_STORAGE)


### PR DESCRIPTION
Fix build failed when the following kconfigs are disabled.

CONFIG_BT_ESL_TAG_BT_KEY_STORAGE
CONFIG_BT_ESL_TAG_STORAGE
CONFIG_BT_ESL_AP_AUTO_MODE